### PR TITLE
[util-livecd] dont activate swap automatically

### DIFF
--- a/lib/util-livecd.sh
+++ b/lib/util-livecd.sh
@@ -380,7 +380,8 @@ configure_machine_id(){
 configure_swap(){
 	local swapdev="$(fdisk -l 2>/dev/null | grep swap | cut -d' ' -f1)"
 	if [ -e "${swapdev}" ]; then
-		swapon ${swapdev}
+		# dont actiavte swap automatically as it could corrupt exisiting swap data
+		# swapon ${swapdev}
 		echo "${swapdev} swap swap defaults 0 0 #configured by manjaro-tools" >>/etc/fstab
 	fi
 }


### PR DESCRIPTION
Background:

I have a laptop, and to save time, I usually hibernate it instead of shutdown.

However, if I boot from a Manjaro ISO for testing, it automatically activates my swap partition, such that the data that was already present on the swap partition gets corrupted, and when I boot into my system it is not able to resume.

This patch does not automatically activate existing swap partition.