### PR TITLE
Rework desktop environment autodetection

### DIFF
--- a/bin/buildiso.in
+++ b/bin/buildiso.in
@@ -30,6 +30,8 @@ show_profile(){
 
 			msg2 "initsys: ${initsys}"
 			msg2 "displaymanager: ${displaymanager}"
+			msg2 "default_desktop_executable: ${default_desktop_executable}"
+			msg2 "default_desktop_file: ${default_desktop_file}"
 			msg2 "kernel: ${kernel}"
 			msg2 "efi_boot_loader: ${efi_boot_loader}"
 			msg2 "efi_part_size: ${efi_part_size}"

--- a/lib/util-iso-calamares.sh
+++ b/lib/util-iso-calamares.sh
@@ -72,8 +72,11 @@ write_calamares_displaymanager_conf(){
 	echo "displaymanagers:" > "$conf"
 	echo "  - ${displaymanager}" >> "$conf"
 	echo '' >> "$conf"
-	echo '#executable: "startkde"' >> "$conf"
-	echo '#desktopFile: "plasma"' >> "$conf"
+	if [[ ${default_desktop_executable} != "none" ]] && [[ ${default_desktop_file} != "none" ]]; then
+		echo "defaultDesktopEnvironment:" >> "$conf"
+		echo "    executable: \"${default_desktop_executable}\"" >> "$conf"
+		echo "    desktopFile: \"${default_desktop_file}\"" >> "$conf"
+	fi
 	echo '' >> "$conf"
 	echo "basicSetup: false" >> "$conf"
 }

--- a/lib/util.sh
+++ b/lib/util.sh
@@ -346,6 +346,10 @@ load_profile_config(){
 
 	[[ -z ${displaymanager} ]] && displaymanager="none"
 
+	[[ -z ${default_desktop_executable} ]] && default_desktop_executable="none"
+
+	[[ -z ${default_desktop_file} ]] && default_desktop_file="none"
+
 	[[ -z ${kernel} ]] && kernel="linux318"
 
 	[[ -z ${efi_boot_loader} ]] && efi_boot_loader="grub"


### PR DESCRIPTION
Add default_desktop_executable and default_desktop_file options in profile.conf
Setting both options will bypass displaymanager autodetection and use provided values to configure the displaymanager.
If one or both are not set it will use diplaymanager autodetection and configuration.
Configure displaymanager.conf for calamares.