### PR TITLE
[util-iso-image.sh] (trivial) remove break statement from empty case statements

### DIFF
--- a/lib/util-iso-image.sh
+++ b/lib/util-iso-image.sh
@@ -239,7 +239,7 @@ configure_displaymanager(){
 					'lightdm-kde-greeter.conf')
 						sed -i -e "s/^.*greeter-session=.*/greeter-session=lightdm-kde-greeter/" ${conf}
 					;;
-					*) break ;;
+					*) ;;
 				esac
 			done
 		;;
@@ -264,7 +264,7 @@ configure_displaymanager(){
 				sed -i -e "s|^.*session=.*|session=/usr/bin/$default_desktop_executable|" ${conf}
 			fi
 		;;
-		*) break ;;
+		*) ;;
 	esac
 	if [[ ${displaymanager} != "none" ]];then
 		if [[ ${initsys} == 'openrc' ]];then


### PR DESCRIPTION
Current code displays message like:

  -> Configuring Displaymanager ...
  -> No default desktop environment set, trying to detect it.
  -> No desktop environment detected
/usr/lib/manjaro-tools/util-iso-image.sh: line 267: break: only meaningful in a for, while, or until loop
  -> Configured: none