### PR TITLE
set target install autologin default to 'false'

### DIFF
--- a/lib/util-yaml.sh
+++ b/lib/util-yaml.sh
@@ -153,7 +153,7 @@ write_users_conf(){
     done
     unset IFS
     echo "autologinGroup:  autologin" >> "$conf"
-    echo "doAutologin:     ${autologin}" >> "$conf"
+    echo "doAutologin:     false" >> "$conf"
     echo "sudoersGroup:    wheel" >> "$conf"
     echo "setRootPassword: false" >> "$conf"
     echo "availableShells: /bin/bash, /bin/zsh" >> "$conf"


### PR DESCRIPTION
- currently we apply the setting intended for the live-session, which is 'true'
  I think that's not what we intend for the target install