### PR TITLE
Reduce RAM usage for HTTP PXE boot

### DIFF
--- a/initcpio/hooks/miso
+++ b/initcpio/hooks/miso
@@ -55,10 +55,11 @@ _mnt_sfs() {
     local mnt="${2}"
     local img_fullname="${img##*/}"
     local sfs_dev
+    local oper=$( [[ -n "${ip}" && -n "${miso_http_srv}" ]] && echo "mv" || echo "cp" )
 
     if [[ "${copytoram}" == "y" ]]; then
         msg -n ":: Copying squashfs image to RAM..."
-        if ! cp "${img}" "/run/miso/copytoram/${img_fullname}" ; then
+        if ! "${oper}" "${img}" "/run/miso/copytoram/${img_fullname}" ; then
             echo "ERROR: while copy '${img}' to '/run/miso/copytoram/${img_fullname}'"
             launch_interactive_shell
         fi


### PR DESCRIPTION
Move the .sfs files from the "/run/miso/httpspace" directory to "/run/miso/copytoram" directory instead of copying them while using HTTP PXE boot.
This way, only a single set of the .sfs files will be stored in memory.

Other PXE boot methods (NFS & NBD) remain unaffected.