### PR TITLE
Set linux414 as default kernel

### DIFF
--- a/lib/util.sh
+++ b/lib/util.sh
@@ -313,7 +313,7 @@ init_buildiso(){
 
     [[ -z ${initsys} ]] && initsys="systemd"
 
-    [[ -z ${kernel} ]] && kernel="linux49"
+    [[ -z ${kernel} ]] && kernel="linux414"
 
     [[ -z ${gpgkey} ]] && gpgkey=''
 


### PR DESCRIPTION
Since 17.1.0 is out we can set as default