### PR TITLE
Option to override `extra` option in profile

### DIFF
--- a/bin/buildiso.in
+++ b/bin/buildiso.in
@@ -111,6 +111,7 @@ display_settings(){
     msg2 "images_only: %s" "${images_only}"
     msg2 "iso_only: %s" "${iso_only}"
     msg2 "persist: %s" "${persist}"
+    msg2 "extra: %s" "${extra}"
 
     msg "DIST SETTINGS:"
     msg2 "dist_name: %s" "${dist_name}"
@@ -155,6 +156,7 @@ usage() {
     echo '    -g <key>           The gpg key for sfs signing'
     echo "                       [default: ${gpgkey}]"
     echo '    -m                 Set SquashFS image mode to persistence'
+    echo '    -n                 Build minimal if available (extra=false)'
     echo '    -c                 Disable clean work dir'
     echo '    -x                 Build images only'
     echo '    -z                 Generate iso only'
@@ -169,7 +171,7 @@ usage() {
 
 orig_argv=("$0" "$@")
 
-opts='p:a:b:r:t:k:i:g:czxmvqh'
+opts='p:a:b:r:t:k:i:g:czxmnvqh'
 
 while getopts "${opts}" arg; do
     case "${arg}" in
@@ -185,6 +187,7 @@ while getopts "${opts}" arg; do
         x) images_only=true ;;
         z) iso_only=true ;;
         m) persist=true ;;
+        n) no_extra=true ;;
         v) verbose=true ;;
         q) pretend=true ;;
         h|?) usage 0 ;;

--- a/bin/buildiso.in
+++ b/bin/buildiso.in
@@ -111,7 +111,6 @@ display_settings(){
     msg2 "images_only: %s" "${images_only}"
     msg2 "iso_only: %s" "${iso_only}"
     msg2 "persist: %s" "${persist}"
-    msg2 "extra: %s" "${extra}"
 
     msg "DIST SETTINGS:"
     msg2 "dist_name: %s" "${dist_name}"

--- a/bin/buildiso.in
+++ b/bin/buildiso.in
@@ -155,8 +155,8 @@ usage() {
     echo '    -g <key>           The gpg key for sfs signing'
     echo "                       [default: ${gpgkey}]"
     echo '    -m                 Set SquashFS image mode to persistence'
-    echo '    -n                 Build minimal if available (extra=false)'
     echo '    -c                 Disable clean work dir'
+    echo '    -f                 Build full iso (extra=true)'
     echo '    -x                 Build images only'
     echo '    -z                 Generate iso only'
     echo '                       Requires pre built images (-x)'
@@ -170,7 +170,7 @@ usage() {
 
 orig_argv=("$0" "$@")
 
-opts='p:a:b:r:t:k:i:g:czxmnvqh'
+opts='p:a:b:r:t:k:i:g:cfzxmvqh'
 
 while getopts "${opts}" arg; do
     case "${arg}" in
@@ -183,10 +183,10 @@ while getopts "${opts}" arg; do
         i) initsys="$OPTARG" ;;
         g) gpgkey="$OPTARG" ;;
         c) clean_first=false ;;
+        f) full_iso=true ;;
         x) images_only=true ;;
         z) iso_only=true ;;
-        m) persist=true ;;
-        n) no_extra=true ;;
+        m) persist=true ;;        
         v) verbose=true ;;
         q) pretend=true ;;
         h|?) usage 0 ;;

--- a/lib/util-iso.sh
+++ b/lib/util-iso.sh
@@ -253,18 +253,16 @@ make_iso() {
 
 gen_iso_fn(){
     local vars=() name
-    vars+=("${iso_name}")
-    
-    if ${no_extra}; then
-        vars+=("minimal")
-    fi
-    
+    vars+=("${iso_name}")    
     if ! ${chrootcfg};then
         [[ -n ${profile} ]] && vars+=("${profile}")
     fi
     [[ ${initsys} == 'openrc' ]] && vars+=("${initsys}")
     vars+=("${dist_release}")
     vars+=("${target_branch}")
+    if ${no_extra}; then
+        vars+=("minimal")
+    fi
     vars+=("${target_arch}")    
     for n in ${vars[@]};do
         name=${name:-}${name:+-}${n}

--- a/lib/util-iso.sh
+++ b/lib/util-iso.sh
@@ -260,7 +260,7 @@ gen_iso_fn(){
     [[ ${initsys} == 'openrc' ]] && vars+=("${initsys}")
     vars+=("${dist_release}")
     vars+=("${target_branch}")
-    if ${no_extra}; then
+    if ! ${full_iso}; then
         vars+=("minimal")
     fi
     vars+=("${target_arch}")    

--- a/lib/util-iso.sh
+++ b/lib/util-iso.sh
@@ -255,7 +255,7 @@ gen_iso_fn(){
     local vars=() name
     vars+=("${iso_name}")
     
-    if ${no_extra}: then
+    if ${no_extra}; then
         vars+=("minimal")
     fi
     

--- a/lib/util-iso.sh
+++ b/lib/util-iso.sh
@@ -254,13 +254,18 @@ make_iso() {
 gen_iso_fn(){
     local vars=() name
     vars+=("${iso_name}")
+    
+    if ${no_extra}: then
+        vars+=("minimal")
+    fi
+    
     if ! ${chrootcfg};then
         [[ -n ${profile} ]] && vars+=("${profile}")
     fi
     [[ ${initsys} == 'openrc' ]] && vars+=("${initsys}")
     vars+=("${dist_release}")
     vars+=("${target_branch}")
-    vars+=("${target_arch}")
+    vars+=("${target_arch}")    
     for n in ${vars[@]};do
         name=${name:-}${name:+-}${n}
     done

--- a/lib/util.sh
+++ b/lib/util.sh
@@ -379,8 +379,8 @@ load_profile_config(){
 
     [[ -z ${smb_workgroup} ]] && smb_workgroup=''
 
-    if ${no_extra}; then
-        extra='false'
+    if ${full_iso}; then
+        extra='true'
     fi
     
     basic='true'

--- a/lib/util.sh
+++ b/lib/util.sh
@@ -379,6 +379,10 @@ load_profile_config(){
 
     [[ -z ${smb_workgroup} ]] && smb_workgroup=''
 
+    if ${no_extra}; then
+        extra='false'
+    fi
+    
     basic='true'
     [[ -z ${extra} ]] && extra='false'
 


### PR DESCRIPTION
To avoid creating to separate iso-profiles for basic and extra an option is added.

<strike>**`-n`** which sets **`no_extra=true`**

When profile is parsed in **`util.sh`** in **`load_profile_config()`** a check has been inserted to set **`extra='false`** if **`no_extra`** exist.

Likewise when the **`util-iso.sh`** the **`gen_iso_fn()`** has a similar check to add the word "minimal" to the iso-filename.

eg. **`manjaro-17.1.6-unstable-minimal-x86_64.iso`**</strike>

The PR has been changed to add a `-f` argument to force `extra="true"` and if a basic iso is build it has `minimal` inserted in the filename.

eg. **`manjaro-17.1.6-unstable-minimal-x86_64.iso`**


